### PR TITLE
Update FAQs doc

### DIFF
--- a/src/docs/faqs.md
+++ b/src/docs/faqs.md
@@ -16,8 +16,17 @@ we encourage you to ask it, and we'll add it here.
 
 - [How can I add my question?](#how-can-i-add-my-question)
 - [What is Boson Protocol?](#what-is-boson-protocol)
-- [What is Redeemeum?](#what-is-redeemeum)
-- [When is your next token sale?](#when-is-your-next-token-sale)
+- [Is Boson a platform for minting NFTs?](#is-boson-a-platform-for-minting-nfts)
+- [What can I exchange with Boson commitment tokens](#what-can-i-exchange-with-boson-commitment-tokens)
+- [What does the BOSON token do?](#what-does-the-$boson-token-do)
+- [What is the Boson DAO?](#what-is-the-boson-dao)
+- [What is an arbitrator?](#what-is-an-arbitrator)
+- [Who is Boson’s target market?](#who-is-bosons-target-market)
+- [What is the dCommerce stack?](#what-is-the-dcommerce-stack)
+- [Which blockchain will you use to build Boson Protocol?](#which-blockchain-will-you-use-to-build-boson-protocol)
+- [How will Boson circumvent high gas fees?](#how-will-boson-circumvent-high-gas-fees)
+- [How do I contribute to the project?](#how-do-i-contribute-to-the-project)
+- [Where can I find out more about Boson?](#where-can-i-find-out-more-about-boson)
 
 ## How can I add my question?
 
@@ -38,25 +47,62 @@ would love to have questions which are actually frequently asked.
 
 ## What is Boson Protocol?
 
-Boson Protocol is three things:
+A decentralized infrastructure for enabling  autonomous commercial exchanges of anyThing, specifically off-chain items.  Boson is a peer-to-peer system which replicates the benefits of a market intermediary, without the disbenefits of centralized systems.
 
-- A protocol, comprised of modular components, for tokenizing Things and thus
-  enabling smart contracts to perform on-chain financial transfers coordinated
-  with the off-chain, often physical, delivery of goods and services.
-- A foundation, currently funded by an external company, Redeemeum, which works
-  on the wider Boson Protocol ecosystem.
-- A wider community of developers working on the protocol.
+## Is Boson a platform for minting NFTs?
 
-## What is Redeemeum?
+No. Boson Commitment tokens are a type of NFT encoded with game theory that represent a promise to redeem a particular item. While it is entirely possible for buyers and sellers to agree to transact existing NFTs using Boson, the protocol’s real power comes from its ability to treat off-chain assets in the same way as on-chain assets: in other words, solving the physical redemption problem.
 
-Redeemeum is a company that the Boson Protocol team has set up to acquire
-funding and to directly employ developers. The goal is that this company will
-work on tools and systems which contribute to the Boson Protocol ecosystem, and
-that it will eventually be one of many such companies - similar to Ethereum and
-the Ethereum Foundation, or Protocol Labs and Filecoin.
+## What can I exchange with Boson commitment tokens?
 
-## When is your next token sale?
+Project Multiverse is the all-encompassing term we use to describe Boson’s Generic Exchange Mechanism. The idea of a Generic Exchange Mechanism is to create a frictionless system that does not distinguish between digital and physical goods and services. For example, imagine an event where tickets are issued in the form of Commitment NFTs, which also confer the right to physical swag and collectibles, plus also a video of the event.
 
-These docs concern the Boson Protocol codebase and do not relate to token sales.
-For those questions, you'd best go to our
-[Telegram](https://t.me/bosonprotocol).
+By establishing a generic standard for the exchange mechanism and introducing common interfaces to govern those exchanges we allow Boson Protocol to power any kind of commercial exchange.
+
+## What does the BOSON token do?
+
+The $BOSON token is the core economic unit of the Boson ecosystem. Growth in the value of the token is driven by establishing an economic flywheel, following the [dCommerce sustainability loop](https://medium.com/bosonprotocol/introducing-the-dcommerce-sustainability-loop-1d72026636d0).
+
+## What is the Boson DAO?
+
+The dCommerce DAO will fund projects that build core Boson Protocol software, applications, tools and integrations, as well as ensuring the growth of the ecosystem via temporary growth policies, such as supply and demand farming.
+
+Revenue generation from projects and initiatives is funnelled back into the DAO, with a fraction of all revenue being used to buy and burn $BOSON. To get the “economic flywheel” going, part of the “network rewards fund” is used to fund the dCommerce DAO until it is self sustaining.
+The perpetual funding of the dCommerce DAO is ensured through a minimally extractive fee on transaction coordination and data monetization facilitated by Boson Protocol. $BOSON token holders will govern the dCommmerce DAO. For more info see our [Governance design principles](https://medium.com/bosonprotocol/governance-design-principles-c7565492512) and $BOSON ecosystem value flows articles.
+
+## What is an arbitrator?
+
+Arbitration is a different word for dispute management.
+
+"Arbitration is a procedure in which a dispute is submitted, by agreement of the parties, to one or more arbitrators who make a binding decision on the dispute."
+
+The challenge that Boson Protocol is taking is automating and thus decentralising arbitration with minimised human intervention.
+
+## Who is Boson’s target market?
+
+Everyone in the world who wants to buy or sell anyThing, whatever and wherever it is. The Protocol is capable of facilitating arbitration-minimized exchange for anyThing, whether digital or physical. 
+
+## What is the dCommerce stack?
+
+Boson Protocol’s vision is to enable a decentralized commerce ecosystem by funding and enabling the development of a stack of specialist applications to disrupt, demonopolize and democratize commerce.
+
+Hence we are building out a collectively maintained infrastructure made up of smaller, composable services for commerce: open, transparent, minimally extractive, and resistant to capture. Read more about the dCommerce stack [here](https://medium.com/bosonprotocol/the-dcommerce-stack-disrupting-commerce-with-a-web-3-ecosystem-1f0156a8afa4).
+
+## Which blockchain will you use to build Boson Protocol?
+
+The goal of Boson Protocol is to be a pluggable web3 component. We are blockchain agnostic as long as the base-layer meet our requirements of security, decentralization and scalability.
+
+## How will Boson circumvent high gas fees?
+
+No specifics are available at this stage, but many scaling and gas reduction options are being considered. Boson Protocol is chain agnostic and will pursue the options that are best suited to the project and community when the opportunity arises. 
+
+A cross-chain/interoperable future for the ecosystem is definitely the plan.
+
+## How do I contribute to the project?
+
+We welcome contributions. Details of how the code works and how to submit pull requests are [here](https://github.com/bosonprotocol/docs.bosonprotocol.io).  If you would like to know more about working at Boson, full details of our hiring program [here](https://boards.greenhouse.io/bosonprotocol). 
+
+## Where can I find out more about Boson?
+
+Read the [Litepaper](https://www.bosonprotocol.io/images/210222_Boson_Lightpaper%20v1-1.pdf), [dCommerce stack report](https://www.bosonprotocol.io/images/docs_fe56dc73-a886-4c02-88b8-67b58c03d4bd_doc.pdf) or [White Paper](https://www.bosonprotocol.io/images/Boson_Protocol_Whitepaper_1_1_Nov.pdf), follow us on [Twitter](https://twitter.com/BosonProtocol), join our [Telegram](https://t.me/bosonprotocol) and read our posts on [Medium](https://medium.com/bosonprotocol).
+


### PR DESCRIPTION
Made changes to bring this into line with the recent FAQs published on Medium as the previous content was outdated. Am assuming that the Gitbook build process will automate the in-page anchor links from the text of the headings, but if not, please ask me to amend.